### PR TITLE
[130] Support for the Message Templates API

### DIFF
--- a/build.savant
+++ b/build.savant
@@ -15,7 +15,7 @@
  */
 savantVersion = "1.0.0"
 
-project(group: "io.fusionauth", name: "fusionauth-node-client", version: "1.21.1", licenses: ["ApacheV2_0"]) {
+project(group: "io.fusionauth", name: "fusionauth-node-client", version: "1.22.0", licenses: ["ApacheV2_0"]) {
   workflow {
     standard()
   }

--- a/build.savant
+++ b/build.savant
@@ -15,7 +15,7 @@
  */
 savantVersion = "1.0.0"
 
-project(group: "io.fusionauth", name: "fusionauth-node-client", version: "1.22.0", licenses: ["ApacheV2_0"]) {
+project(group: "io.fusionauth", name: "fusionauth-node-client", version: "1.23.0", licenses: ["ApacheV2_0"]) {
   workflow {
     standard()
   }

--- a/lib/FusionAuthClient.js
+++ b/lib/FusionAuthClient.js
@@ -380,6 +380,24 @@ FusionAuthClient.prototype = {
   },
 
   /**
+   * Creates an message template. You can optionally specify an Id for the template, if not provided one will be generated.
+   *
+   * @param {?UUIDString} messageTemplateId (Optional) The Id for the template. If not provided a secure random UUID will be generated.
+   * @param {MessageTemplateRequest} request The request object that contains all of the information used to create the message template.
+   * @return {Promise<ClientResponse<MessageTemplateResponse>>} A Promise for the FusionAuth call.
+   */
+  createMessageTemplate: function(messageTemplateId, request) {
+    return new Promise((resolve, reject) => {
+      this._start()
+          .uri('/api/message/template')
+          .urlSegment(messageTemplateId)
+          .setJSONBody(request)
+          .post()
+          .go(this._responseHandler(resolve, reject));
+    });
+  },
+
+  /**
    * Creates a tenant. You can optionally specify an Id for the tenant, if not provided one will be generated.
    *
    * @param {?UUIDString} tenantId (Optional) The Id for the tenant. If not provided a secure random UUID will be generated.
@@ -788,6 +806,22 @@ FusionAuthClient.prototype = {
       this._start()
           .uri('/api/lambda')
           .urlSegment(lambdaId)
+          .delete()
+          .go(this._responseHandler(resolve, reject));
+    });
+  },
+
+  /**
+   * Deletes the message template for the given Id.
+   *
+   * @param {UUIDString} messageTemplateId The Id of the message template to delete.
+   * @return {Promise<ClientResponse<void>>} A Promise for the FusionAuth call.
+   */
+  deleteMessageTemplate: function(messageTemplateId) {
+    return new Promise((resolve, reject) => {
+      this._start()
+          .uri('/api/message/template')
+          .urlSegment(messageTemplateId)
           .delete()
           .go(this._responseHandler(resolve, reject));
     });
@@ -1629,6 +1663,24 @@ FusionAuthClient.prototype = {
       this._start()
           .uri('/api/lambda')
           .urlSegment(lambdaId)
+          .setJSONBody(request)
+          .patch()
+          .go(this._responseHandler(resolve, reject));
+    });
+  },
+
+  /**
+   * Updates, via PATCH, the message template with the given Id.
+   *
+   * @param {UUIDString} messageTemplateId The Id of the message template to update.
+   * @param {MessageTemplateRequest} request The request that contains just the new message template information.
+   * @return {Promise<ClientResponse<MessageTemplateResponse>>} A Promise for the FusionAuth call.
+   */
+  patchMessageTemplate: function(messageTemplateId, request) {
+    return new Promise((resolve, reject) => {
+      this._start()
+          .uri('/api/message/template')
+          .urlSegment(messageTemplateId)
           .setJSONBody(request)
           .patch()
           .go(this._responseHandler(resolve, reject));
@@ -2579,6 +2631,36 @@ FusionAuthClient.prototype = {
           .urlParameter('applicationId', applicationId)
           .urlParameter('start', start)
           .urlParameter('end', end)
+          .get()
+          .go(this._responseHandler(resolve, reject));
+    });
+  },
+
+  /**
+   * Retrieves the message template for the given Id. If you don't specify the id, this will return all of the message templates.
+   *
+   * @param {?UUIDString} messageTemplateId (Optional) The Id of the message template.
+   * @return {Promise<ClientResponse<MessageTemplateResponse>>} A Promise for the FusionAuth call.
+   */
+  retrieveMessageTemplate: function(messageTemplateId) {
+    return new Promise((resolve, reject) => {
+      this._start()
+          .uri('/api/message/template')
+          .urlSegment(messageTemplateId)
+          .get()
+          .go(this._responseHandler(resolve, reject));
+    });
+  },
+
+  /**
+   * Retrieves all of the message templates.
+   *
+   * @return {Promise<ClientResponse<MessageTemplateResponse>>} A Promise for the FusionAuth call.
+   */
+  retrieveMessageTemplates: function() {
+    return new Promise((resolve, reject) => {
+      this._start()
+          .uri('/api/message/template')
           .get()
           .go(this._responseHandler(resolve, reject));
     });
@@ -3684,6 +3766,24 @@ FusionAuthClient.prototype = {
       this._start()
           .uri('/api/lambda')
           .urlSegment(lambdaId)
+          .setJSONBody(request)
+          .put()
+          .go(this._responseHandler(resolve, reject));
+    });
+  },
+
+  /**
+   * Updates the message template with the given Id.
+   *
+   * @param {UUIDString} messageTemplateId The Id of the message template to update.
+   * @param {MessageTemplateRequest} request The request that contains all of the new message template information.
+   * @return {Promise<ClientResponse<MessageTemplateResponse>>} A Promise for the FusionAuth call.
+   */
+  updateMessageTemplate: function(messageTemplateId, request) {
+    return new Promise((resolve, reject) => {
+      this._start()
+          .uri('/api/message/template')
+          .urlSegment(messageTemplateId)
           .setJSONBody(request)
           .put()
           .go(this._responseHandler(resolve, reject));
@@ -6083,16 +6183,16 @@ var KeyUse = {
 /**
  * @typedef {Object} LambdaConfiguration
  *
- * @property {UUIDString} [reconcileId]
+ * @property {UUIDString} [accessTokenPopulateId]
+ * @property {UUIDString} [idTokenPopulateId]
+ * @property {UUIDString} [samlv2PopulateId]
  */
 
 
 /**
  * @typedef {Object} LambdaConfiguration
  *
- * @property {UUIDString} [accessTokenPopulateId]
- * @property {UUIDString} [idTokenPopulateId]
- * @property {UUIDString} [samlv2PopulateId]
+ * @property {UUIDString} [reconcileId]
  */
 
 

--- a/lib/FusionAuthClient.js
+++ b/lib/FusionAuthClient.js
@@ -6083,16 +6083,16 @@ var KeyUse = {
 /**
  * @typedef {Object} LambdaConfiguration
  *
- * @property {UUIDString} [accessTokenPopulateId]
- * @property {UUIDString} [idTokenPopulateId]
- * @property {UUIDString} [samlv2PopulateId]
+ * @property {UUIDString} [reconcileId]
  */
 
 
 /**
  * @typedef {Object} LambdaConfiguration
  *
- * @property {UUIDString} [reconcileId]
+ * @property {UUIDString} [accessTokenPopulateId]
+ * @property {UUIDString} [idTokenPopulateId]
+ * @property {UUIDString} [samlv2PopulateId]
  */
 
 

--- a/lib/FusionAuthClient.js
+++ b/lib/FusionAuthClient.js
@@ -2653,6 +2653,22 @@ FusionAuthClient.prototype = {
   },
 
   /**
+   * Creates a preview of the message template provided in the request, normalized to a given locale.
+   *
+   * @param {PreviewMessageTemplateRequest} request The request that contains the email template and optionally a locale to render it in.
+   * @return {Promise<ClientResponse<PreviewMessageTemplateResponse>>} A Promise for the FusionAuth call.
+   */
+  retrieveMessageTemplatePreview: function(request) {
+    return new Promise((resolve, reject) => {
+      this._start()
+          .uri('/api/message/template/preview')
+          .setJSONBody(request)
+          .post()
+          .go(this._responseHandler(resolve, reject));
+    });
+  },
+
+  /**
    * Retrieves all of the message templates.
    *
    * @return {Promise<ClientResponse<MessageTemplateResponse>>} A Promise for the FusionAuth call.
@@ -6512,6 +6528,17 @@ var LogoutBehavior = {
 
 
 /**
+ * An incredible simplified view of a message
+ *
+ * @author Michael Sleevi
+ *
+ * @typedef {Object} Message
+ *
+ * @property {string} [text]
+ */
+
+
+/**
  * Stores an message template used to distribute messages;
  *
  * @author Michael Sleevi
@@ -6880,6 +6907,24 @@ var OAuthErrorType = {
  * @typedef {Object} PendingResponse
  *
  * @property {Array<User>} [users]
+ */
+
+
+/**
+ * @author Michael Sleevi
+ *
+ * @typedef {Object} PreviewMessageTemplateRequest
+ *
+ * @property {string} [locale]
+ * @property {MessageTemplate} [messageTemplate]
+ */
+
+
+/**
+ * @typedef {Object} PreviewMessageTemplateResponse
+ *
+ * @property {Errors} [errors]
+ * @property {Message} [message]
  */
 
 

--- a/lib/FusionAuthClient.js
+++ b/lib/FusionAuthClient.js
@@ -6183,16 +6183,16 @@ var KeyUse = {
 /**
  * @typedef {Object} LambdaConfiguration
  *
- * @property {UUIDString} [accessTokenPopulateId]
- * @property {UUIDString} [idTokenPopulateId]
- * @property {UUIDString} [samlv2PopulateId]
+ * @property {UUIDString} [reconcileId]
  */
 
 
 /**
  * @typedef {Object} LambdaConfiguration
  *
- * @property {UUIDString} [reconcileId]
+ * @property {UUIDString} [accessTokenPopulateId]
+ * @property {UUIDString} [idTokenPopulateId]
+ * @property {UUIDString} [samlv2PopulateId]
  */
 
 

--- a/lib/FusionAuthClient.js
+++ b/lib/FusionAuthClient.js
@@ -6412,6 +6412,41 @@ var LogoutBehavior = {
 
 
 /**
+ * Stores an message template used to distribute messages;
+ *
+ * @author Michael Sleevi
+ *
+ * @typedef {Object} MessageTemplate
+ *
+ * @property {string} [defaultTemplate]
+ * @property {UUIDString} [id]
+ * @property {number} [insertInstant]
+ * @property {number} [lastUpdateInstant]
+ * @property {LocalizedStrings} [localizedTemplates]
+ * @property {string} [name]
+ */
+
+
+/**
+ * A Message Template Request to the API
+ *
+ * @author Michael Sleevi
+ *
+ * @typedef {Object} MessageTemplateRequest
+ *
+ * @property {MessageTemplate} [messageTemplate]
+ */
+
+
+/**
+ * @typedef {Object} MessageTemplateResponse
+ *
+ * @property {MessageTemplate} [messageTemplate]
+ * @property {Array<MessageTemplate>} [messageTemplates]
+ */
+
+
+/**
  * @typedef {Object} MetaData
  *
  * @property {DeviceInfo} [device]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@fusionauth/node-client",
-  "version": "1.22.0",
+  "version": "1.23.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@fusionauth/node-client",
-  "version": "1.21.1",
+  "version": "1.22.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fusionauth/node-client",
-  "version": "1.21.1",
+  "version": "1.22.0",
   "description": "FusionAuth Client written in Node.js",
   "private": false,
   "contributors": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fusionauth/node-client",
-  "version": "1.22.0",
+  "version": "1.23.0",
   "description": "FusionAuth Client written in Node.js",
   "private": false,
   "contributors": [


### PR DESCRIPTION
Related Issues
----

* [130](https://github.com/FusionAuth/fusionauth-internal-issues/issues/130)

Background
-----

This PR incorporates the client changes for the support of enhanced MFA functionality.

Implementation Details
-----

* Adds new Message Template methods for interacting with the upcoming APIs, namely:
  * Supports PUT /api/message/template/{id}
  * Supports GET /api/message/template/{id}
  * Supports GET /api/message/template
  * Supports POST /api/message/template
  * Supports DELETE /api/message/template
  * Supports PATCH /api/message/template/{id}
  * Supports POST /api/message/template/preview
* Adds new Domain objects and responses for the upcoming APIs, namely:
  * `io.fusionauth.domain.api.MessageTemplateRequest`
  * `io.fusionauth.domain.api.MessageTemplateResponse`
  * `io.fusionauth.domain.api.PreviewMessageTemplateRequest`
  * `io.fusionauth.domain.api.PreviewMessageTemplateResponse`
  * `io.fusionauth.domain.message.MessageTemplate`
  * `io.fusionauth.domain.message.Message`